### PR TITLE
Add plugin metadata for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,17 @@ The plugin is designed to be compiled as part of CloudCompare's plugin system.
 
 Once compiled and loaded, select several point clouds in CloudCompare and trigger the MultiCloud Alignment action from the Plugins menu.
 The first selected cloud acts as the reference and all other clouds will be aligned to it using the standard ICP algorithm.
+
+## Open3D Example
+
+The `scripts/fgr_multi_align.py` script demonstrates how to perform a fast global
+registration using Open3D's FGR algorithm followed by an ICP refinement. It
+aligns multiple clouds provided as `.ply` files on the command line and prints
+the resulting 4x4 transformation matrices.
+
+```bash
+python scripts/fgr_multi_align.py cloud1.ply cloud2.ply cloud3.ply
+```
+
+This script illustrates how external libraries mentioned in
+`research_methods.md` can complement the basic ICP-based plugin.

--- a/plugins/MultiAlign/include/MultiAlign.h
+++ b/plugins/MultiAlign/include/MultiAlign.h
@@ -8,7 +8,8 @@ class QAction;
 class MultiAlignPlugin : public QObject, public ccStdPluginInterface
 {
     Q_OBJECT
-    Q_INTERFACES(ccStdPluginInterface)
+    Q_INTERFACES(ccPluginInterface ccStdPluginInterface)
+    Q_PLUGIN_METADATA(IID "cccorp.cloudcompare.plugin.MultiAlign" FILE "../info.json")
 
 public:
     explicit MultiAlignPlugin(QObject* parent = nullptr);
@@ -23,9 +24,11 @@ public:
 
 private slots:
     void doAction();
+    void doFgrAction();
 
 private:
     QAction* m_action;
+    QAction* m_fgrAction;
 };
 
 #endif // MULTI_ALIGN_PLUGIN_H

--- a/plugins/MultiAlign/info.json
+++ b/plugins/MultiAlign/info.json
@@ -1,20 +1,26 @@
 {
-    "type": "Standard",
-    "core": true,
-    "name": "MultiCloud Alignment",
-    "icon": ":/CC/plugin/MultiAlign/icon.png",
-    "description": "Align multiple point clouds using sequential ICP steps.",
-    "authors": [
-        { "name": "Your Name" }
-    ],
-    "references": [
-        {
-            "text": "ICP: Besl, P.J.; McKay, N.D., 'A Method for Registration of 3-D Shapes', TPAMI 1992",
-            "url": "https://ieeexplore.ieee.org/document/121791"
-        },
-        {
-            "text": "CloudCompare Documentation",
-            "url": "https://www.cloudcompare.org/doc"
-        }
-    ]
+  "type": "Standard",
+  "core": true,
+  "name": "MultiCloud Alignment",
+  "icon": ":/CC/plugin/MultiAlign/icon.png",
+  "description": "Align multiple point clouds using sequential ICP steps.",
+  "authors": [
+    {
+      "name": "Your Name"
+    }
+  ],
+  "references": [
+    {
+      "text": "ICP: Besl, P.J.; McKay, N.D., 'A Method for Registration of 3-D Shapes', TPAMI 1992",
+      "url": "https://ieeexplore.ieee.org/document/121791"
+    },
+    {
+      "text": "CloudCompare Documentation",
+      "url": "https://www.cloudcompare.org/doc"
+    },
+    {
+      "text": "Open3D Fast Global Registration",
+      "url": "https://github.com/isl-org/Open3D"
+    }
+  ]
 }

--- a/plugins/MultiAlign/scripts/fgr_multi_align.py
+++ b/plugins/MultiAlign/scripts/fgr_multi_align.py
@@ -1,0 +1,47 @@
+import open3d as o3d
+import numpy as np
+import sys
+
+
+def preprocess(pcd, voxel_size):
+    pcd_down = pcd.voxel_down_sample(voxel_size)
+    pcd_down.estimate_normals(
+        o3d.geometry.KDTreeSearchParamHybrid(radius=voxel_size * 2, max_nn=30))
+    fpfh = o3d.pipelines.registration.compute_fpfh_feature(
+        pcd_down,
+        o3d.geometry.KDTreeSearchParamHybrid(radius=voxel_size * 5, max_nn=100))
+    return pcd_down, fpfh
+
+
+def align_pair(source, target, voxel_size):
+    s_down, s_fpfh = preprocess(source, voxel_size)
+    t_down, t_fpfh = preprocess(target, voxel_size)
+    result = o3d.pipelines.registration.registration_fgr_based_on_feature_matching(
+        s_down, t_down, s_fpfh, t_fpfh,
+        o3d.pipelines.registration.FastGlobalRegistrationOption(
+            maximum_correspondence_distance=voxel_size * 5))
+    result = o3d.pipelines.registration.registration_icp(
+        source, target, voxel_size * 1.5, result.transformation,
+        o3d.pipelines.registration.TransformationEstimationPointToPlane())
+    return result.transformation
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: fgr_multi_align.py cloud1.ply cloud2.ply [cloud3.ply ...]")
+        sys.exit(1)
+
+    paths = sys.argv[1:]
+    clouds = [o3d.io.read_point_cloud(p) for p in paths]
+    voxel = 0.05
+    base = clouds[0]
+    transforms = [np.eye(4)]
+    for cloud in clouds[1:]:
+        T = align_pair(cloud, base, voxel)
+        cloud.transform(T)
+        transforms.append(T)
+        base += cloud
+
+    for T in transforms:
+        flat = " ".join(f"{v:.6f}" for v in T.flatten())
+        print(flat)


### PR DESCRIPTION
## Summary
- fix MultiAlign plugin header to include plugin metadata macros

## Testing
- `python -m py_compile plugins/MultiAlign/scripts/fgr_multi_align.py`
- `pip install open3d plyfile pycpd -q`
- `cmake -B build -S .` *(fails: Unknown CMake command `AddPlugin`)*

------
https://chatgpt.com/codex/tasks/task_e_684479e229408331816e61900a548119