### PR TITLE
Improve multi-align plugin stability

### DIFF
--- a/plugins/MultiAlign/scripts/fgr_multi_align.py
+++ b/plugins/MultiAlign/scripts/fgr_multi_align.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import open3d as o3d
 import numpy as np
 import sys
@@ -49,4 +50,4 @@ if __name__ == "__main__":
 
     for T in transforms:
         flat = " ".join(f"{v:.6f}" for v in T.flatten())
-        print(flat)
+        print(flat, flush=True)


### PR DESCRIPTION
## Summary
- clean up unused code in `MultiAlignPlugin.cpp`
- add missing `QCoreApplication` include
- improve FGR subprocess error handling
- make the FGR script executable and flush outputs

## Testing
- `python3 plugins/MultiAlign/scripts/fgr_multi_align.py` *(fails: Usage message)*
- `python3 plugins/MultiAlign/scripts/fgr_multi_align.py 0.05 dummy1.ply dummy2.ply` *(fails: missing file error)*

------
https://chatgpt.com/codex/tasks/task_e_6844836ffcdc833189f97b8eace984f3