### PR TITLE
Improve multi-align plugin stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,31 @@ This repository contains a sample CloudCompare plugin that demonstrates how to a
 ## Building
 
 The plugin is designed to be compiled as part of CloudCompare's plugin system.
- - Clone CloudCompare and place this repository under the plugins directory or add it as an external plugin.
-- Then enable the MultiAlignPlugin option in CMake and build CloudCompare normally.
+- Clone CloudCompare and place this repository under the `plugins` directory or add it as an external plugin.
+- Then enable the `MultiAlignPlugin` option in CMake and build CloudCompare normally.
+
+### Building on macOS (Apple Silicon)
+
+1. Install the required tools via Homebrew:
+   ```bash
+   brew install cmake qt5 git
+   ```
+2. Fetch CloudCompare 2.14 sources and this repository:
+   ```bash
+   git clone --branch v2.14 https://github.com/CloudCompare/CloudCompare.git
+   cd CloudCompare/plugins
+   git clone <this repo url> CC-MPC-Align
+   ```
+3. Create a build directory and configure with CMake, enabling the plugin:
+   ```bash
+   mkdir ../build && cd ../build
+   cmake -DCMAKE_PREFIX_PATH=$(brew --prefix qt5) -DPLUGIN_MULTIALIGNPLUGIN=ON ..
+   ```
+4. Build CloudCompare as usual:
+   ```bash
+   cmake --build . --target ALL_BUILD --config Release
+   ```
+5. The resulting CloudCompare.app will contain the plugin in `Contents/MacOS/plugins`.
 
 ## Usage
 

--- a/plugins/MultiAlign/scripts/fgr_multi_align.py
+++ b/plugins/MultiAlign/scripts/fgr_multi_align.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import open3d as o3d
 import numpy as np
 import sys
@@ -49,4 +50,4 @@ if __name__ == "__main__":
 
     for T in transforms:
         flat = " ".join(f"{v:.6f}" for v in T.flatten())
-        print(flat)
+        print(flat, flush=True)


### PR DESCRIPTION
## Summary
- clean up unused code in `MultiAlignPlugin.cpp`
- add missing `QCoreApplication` include
- improve FGR subprocess error handling
- make the FGR script executable and flush outputs
- document how to build the plugin on macOS

## Testing
- `python3 -m py_compile plugins/MultiAlign/scripts/fgr_multi_align.py`
- `python3 plugins/MultiAlign/scripts/fgr_multi_align.py` *(fails: Usage message)*
- `python3 plugins/MultiAlign/scripts/fgr_multi_align.py 0.1 dummy1.ply dummy2.ply` *(fails: missing file error)*


------
https://chatgpt.com/codex/tasks/task_e_6844836ffcdc833189f97b8eace984f3