### PR TITLE
Improve MultiAlign robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+plugins/MultiAlign/scripts/__pycache__/
+CC-SDK/

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Once compiled and loaded, select several point clouds in CloudCompare and trigge
 The first selected cloud acts as the reference and all other clouds will be aligned to it using the standard ICP algorithm.
 If the dialog's **Save transformations to file** option is checked, all resulting
 4x4 matrices (including the identity for the reference cloud) are written to
-`alignment_transforms.txt` next to the application binary.
+`alignment_transforms.txt` in your Documents folder.
 
 ## Open3D Example
 


### PR DESCRIPTION
## Summary
- handle non-cloud selections consistently
- place transform output in user documents directory
- provide better error info for the FGR process
- make python FGR script validate inputs and reuse preprocessing
- update documentation
- add gitignore

## Testing
- `cmake ..` *(fails: Could not find CloudCompareConfig.cmake)*
- `python3 -m py_compile plugins/MultiAlign/scripts/fgr_multi_align.py`

------
https://chatgpt.com/codex/tasks/task_e_684497cecaf883318dfce68e3334ae24