### PR TITLE
Fix cmake version for MultiAlign

### DIFF
--- a/plugins/MultiAlign/CMakeLists.txt
+++ b/plugins/MultiAlign/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(MultiAlignPlugin)
 
 find_package(CloudCompare REQUIRED


### PR DESCRIPTION
## Summary
- update MultiAlign plugin CMake minimum to 3.5 to match top-level project requirements

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "CloudCompare")*

------
https://chatgpt.com/codex/tasks/task_e_6844ac8b47fc83318db191425349505c