### PR TITLE
Fix cmake version for MultiAlign

### DIFF
--- a/plugins/MultiAlign/CMakeLists.txt
+++ b/plugins/MultiAlign/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(MultiAlignPlugin)
 
 find_package(CloudCompare REQUIRED
-  PATHS ${CLOUDCOMPARE_DIR}
+  PATHS "${CLOUDCOMPARE_DIR}"
   NO_DEFAULT_PATH
 )
 find_package(Qt5Widgets REQUIRED)


### PR DESCRIPTION
## Summary
- update MultiAlign plugin CMake minimum to 3.5 FATAL_ERROR
- quote `CLOUDCOMPARE_DIR` in search path

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "CloudCompare")*

------
https://chatgpt.com/codex/tasks/task_e_6844ac8b47fc83318db191425349505c