### PR TITLE
Set plugin suffix per OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ cmake .. -DCMAKE_BUILD_TYPE=Release \
 cmake --build . --config Release
 ```
 
-The resulting `MultiAlignPlugin.so` will be located in `build/plugins/`.
+The resulting plugin file (`MultiAlignPlugin.dll` on Windows, `.dylib` on macOS,
+`.so` on Linux) will be located in `build/plugins/`.
 
 ## Usage
 

--- a/plugins/MultiAlign/CMakeLists.txt
+++ b/plugins/MultiAlign/CMakeLists.txt
@@ -29,7 +29,13 @@ target_link_libraries(${PROJECT_NAME}
   Qt5::Widgets
 )
 
+if(APPLE)
+  set(plugin_suffix ".dylib")
+elseif(WIN32)
+  set(plugin_suffix ".dll")
+else()
+  set(plugin_suffix ".so")
+endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/plugins"
-  SUFFIX ".so"
-)
+  SUFFIX "${plugin_suffix}")


### PR DESCRIPTION
## Summary
- set `plugin_suffix` per operating system
- update README to mention OS-specific plugin names

## Testing
- `python3 -m py_compile plugins/MultiAlign/scripts/fgr_multi_align.py`


------
https://chatgpt.com/codex/tasks/task_e_6844b93a6bac8331912d24275d8c6fe4