### PR TITLE
Install FGR helper script with MultiAlign plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ cmake --build . --config Release
 ```
 
 The resulting `MultiAlignPlugin.so` will be located in `build/plugins/`.
+Running `cmake --install .` installs the plugin and copies the helper script
+`fgr_multi_align.py` to `<install prefix>/plugins/MultiAlign/scripts` so the
+FGR Global Align action can locate it at runtime.
 
 ## Usage
 

--- a/plugins/MultiAlign/CMakeLists.txt
+++ b/plugins/MultiAlign/CMakeLists.txt
@@ -33,3 +33,11 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/plugins"
   SUFFIX ".so"
 )
+
+install(TARGETS ${PROJECT_NAME}
+  LIBRARY DESTINATION plugins
+)
+
+install(PROGRAMS scripts/fgr_multi_align.py
+  DESTINATION plugins/MultiAlign/scripts
+)

--- a/plugins/MultiAlign/src/MultiAlignPlugin.cpp
+++ b/plugins/MultiAlign/src/MultiAlignPlugin.cpp
@@ -14,6 +14,7 @@
 #include <QFile>
 #include <QTextStream>
 #include <QDir>
+#include <QFileInfo>
 #include <QStandardPaths>
 
 #include <QAction>
@@ -203,7 +204,15 @@ void MultiAlignPlugin::doFgrAction()
         files << path;
     }
 
-    QString script = QCoreApplication::applicationDirPath() + QLatin1String("/../plugins/MultiAlign/scripts/fgr_multi_align.py");
+    QDir pluginDir(QCoreApplication::applicationDirPath());
+    pluginDir.cdUp();
+    QString script = pluginDir.filePath(QStringLiteral("plugins/MultiAlign/scripts/fgr_multi_align.py"));
+    if (!QFileInfo::exists(script))
+    {
+        // fall back to the source tree when running uninstalled
+        QDir srcDir(QFileInfo(__FILE__).absolutePath());
+        script = srcDir.filePath(QStringLiteral("../scripts/fgr_multi_align.py"));
+    }
     QStringList args;
     args << script << QString::number(voxel);
     args.append(files);


### PR DESCRIPTION
## Summary
- install the plugin library and helper script with CMake
- look up the helper script from the installed location
- document installation of the helper script in README

## Testing
- `cmake ..` *(fails: Could not find CloudCompare package)*

------
https://chatgpt.com/codex/tasks/task_e_6844b91065588331960e0f90d1d15ec4